### PR TITLE
Simplify max color value calculation

### DIFF
--- a/PiAGr8w4.py
+++ b/PiAGr8w4.py
@@ -1282,9 +1282,7 @@ while True:
          if rgbw == 4:
             ima = (imrc + imgc + imbc )/3
          else:
-            ima = imrc
-            imgc = max(imgc, ima)
-            imbc = max(imbc, ima)
+            ima = max(imrc, imgc, imbc)
          mx.append(ima)
          xcounter += 3
 


### PR DESCRIPTION
also fixes wrong assignments (`imgc`, `imbc` to `ima`)
